### PR TITLE
feat: Initialize repository structure with epic folders and READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,72 +1,34 @@
-# EcoRoute Advisor 
+# Project Title: Fleet Management and Optimisation System
 
-**EcoRoute Advisor** is a virtual driving range for experimenting with eco-friendly routing ideas—no real trucks, SIM cards, or GPS devices required.
+## Overview
+This project aims to develop a comprehensive fleet management and optimisation system. It includes features for simulating fleet operations, optimizing routes for fuel efficiency, providing real-time updates to drivers and fleet managers, generating eco-driving tips, and ensuring data security and auditability.
 
-We replay a CSV of timestamped GPS points into AWS, simulating a live fleet. With telco-edge compute, AI coaching, and real-time dashboards, EcoRoute Advisor showcases the power of AWS for sustainability and latency-sensitive workloads.
+## Epics
 
----
+The project is divided into the following epics:
 
-## Architecture Overview
+1.  **Ingestion**: Handles the initial intake of GPS data.
+    *   *User Story*: As a DevOps engineer, I want to upload a CSV file containing pre-recorded GPS pings so that we can simulate a fleet without hardware.
+2.  **QA Tools**: Provides tools for quality assurance and demo purposes.
+    *   *User Story*: As a QA tester, I want a Postman collection that seeds sample files so that any team-mate can spin up a demo in < 5 min.
+3.  **Optimisation Engine**: Focuses on route optimisation.
+    *   *User Story*: As the optimisation engine, I want to call SageMaker Geospatial every 60 s to recompute shortest paths that avoid congestion so that fuel burn is minimised.
+4.  **Driver Mobile App**: Delivers route information and tips to drivers.
+    *   *User Story*: As a driver, I want my mobile view to highlight the updated route in ≤ 5 s after optimisation so that I can adjust without confusion.
+5.  **Sustainability Analytics**: Generates eco-friendly driving advice.
+    *   *User Story*: As a sustainability analyst, I want Bedrock to generate bite-sized eco-tips based on driving behaviour so that drivers learn how to save fuel.
+6.  **Fleet Manager Dashboard**: Provides a web interface for fleet overview and tip logging.
+    *   *User Story 1*: As a fleet manager, I want the tips logged against each trip so that I can review driver coaching history.
+    *   *User Story 2*: As a dispatcher, I want a web dashboard that shows current vehicle positions, planned routes and litres saved so that I see ROI in real time.
+7.  **DevOps**: Manages infrastructure and deployment.
+    *   *User Story*: As a DevOps engineer, I want to deploy the optimisation Lambda in both a Wavelength Zone (us-wavelength-1) and a standard region (us-east-1) so that we can A/B test latency.
+8.  **Reporting**: Focuses on performance monitoring and alerting.
+    *   *User Story*: As a product owner, I want a Grafana panel that graphs median route-replan latency for both regions so that I can quantify the 20–30 % speedup target.
+9.  **Demo Scripts**: Contains scripts for showcasing specific features.
+    *   *User Story*: As a judge, I want a demo script that throttles bandwidth to 1 Mbps and shows Wavelength still hitting < 1 s replans so that the telco value prop is obvious.
+10. **Security**: Ensures data protection.
+    *   *User Story*: As a security officer, I want all location data encrypted at rest with AWS-managed KMS keys so that we meet basic compliance.
+11. **Audit**: Manages access logging and review.
+    *   *User Story*: As a privacy-conscious fleet manager, I want to view audit logs of who accessed trip data so that I can investigate incidents.
 
-1. **CSV Replay**  
-   A Lambda function replays `vehicles.csv` and streams fake GPS positions to Amazon Location Service (Tracker).
-
-2. **Route Calculation (Region vs Edge)**  
-   Another Lambda (`RoutePlanner`) runs in:
-   - A standard AWS Region (`us-east-1`)
-   - An AWS Wavelength Zone (inside a 5G telco)
-
-   Both use **SageMaker Geospatial APIs** to get fuel-efficient routes.
-
-3. **AI Coaching**  
-   Driving stats (idle time, speed variance) are sent to a **Bedrock InlineAgent** for natural language eco-driving tips.
-
-4. **Real-Time Fan-out**  
-   New data (locations, tips, routes) is saved to **DynamoDB** and broadcast via **AWS AppSync** (GraphQL Subscriptions).
-
-5. **Visualization**  
-   A **Next.js + MapLibre** frontend shows:
-   - Moving truck icons
-   - Eco (green) vs Original (purple) routes
-   - Fuel and CO₂ counters
-   - Edge vs Region replan latency chart
-
----
-
-## AWS Components
-
-| Service                     | Role                                                                 |
-|----------------------------|----------------------------------------------------------------------|
-| Amazon Location Service     | Tracker + map tiles; logs all GPS points.                            |
-| AWS Wavelength              | Runs RoutePlanner at telco edge for low-latency testing.             |
-| SageMaker Geospatial        | Finds fuel-efficient routes using satellite data.                    |
-| Amazon Bedrock (InlineAgent)| Generates plain-English eco-driving tips.                            |
-| AWS AppSync + DynamoDB      | Real-time GraphQL + persistent state storage.                        |
-| Next.js (frontend)          | Delivers dispatcher and driver views from one codebase.              |
-
----
-
-## Construction Stages
-
-| Stage         | What You See on the Dashboard                                  |
-|---------------|---------------------------------------------------------------|
-| `S-1`         | Dots moving on roads from CSV replay                          |
-| `S-2`         | Green route appears + "Litres saved" counter                  |
-| `S-3`         | Latency widget shows Region vs Edge times                     |
-| `S-4`         | AI "eco-tips" pop up beside trucks                           |
-| `S-5`         | Full dispatcher dashboard: vehicles, charts, map              |
-| `S-6`         | Edge latency demo harness for judges                          |
-
----
-
-## Why It Matters
-
-- Transforms offline CSVs into real-time telemetry
-- Showcases real-world 5G + edge compute with **Wavelength**
-- Demonstrates **AI for Sustainability** in motion
-- Ideal for hackathons, AWS demos, or fleet simulations
-
----
-
-## 🚀 Quick Start (coming soon)
-TBD: Setup scripts, sample CSV, and deploy instructions.
+Further details for each epic can be found in their respective directories.

--- a/audit/README.md
+++ b/audit/README.md
@@ -1,0 +1,59 @@
+# Audit & Access Logging
+
+## Purpose
+This section describes the mechanisms for auditing access to data within the EcoRoute Advisor system, specifically focusing on enabling AWS CloudTrail Lake for log retention and querying capabilities.
+
+## User Story
+As a privacy-conscious fleet manager, I want to view audit logs of who accessed trip data so that I can investigate incidents.
+
+## Acceptance Criteria
+-   **AC-1:** AWS CloudTrail Lake is enabled with a 90-day retention period for event data.
+-   **AC-2:** A query performed in CloudTrail Lake for `GetItem` API calls on the `TripTable` (the DynamoDB table storing trip data) by a specific `principalId` returns results in < 30 seconds.
+
+## Audit Strategy
+
+### AWS CloudTrail Lake
+-   **Enablement:** An AWS CloudTrail Lake event data store will be configured.
+-   **Data Events:** The event data store will be configured to include data events, specifically for:
+    -   Amazon DynamoDB: To log item-level access like `GetItem`, `PutItem`, `DeleteItem` on tables such as `TripTable`.
+    -   Amazon S3: To log object-level access for buckets like the `ingest` bucket.
+-   **Retention:** The event data store will be set up with a 90-day retention period for the collected audit logs.
+-   **Querying:** Fleet managers or authorized personnel will be able to query these logs using SQL-like syntax directly in the CloudTrail Lake console.
+
+### Focus on Trip Data Access
+-   The primary concern is auditing access to `TripTable` in DynamoDB, which presumably stores sensitive trip information.
+-   Queries will be designed to filter for:
+    -   `eventName: GetItem` (and potentially other read/write operations like `BatchGetItem`, `Query`, `Scan`).
+    -   `resources.ARN` (matching the ARN of `TripTable`).
+    -   `userIdentity.principalId` (to identify who performed the action).
+
+### Example CloudTrail Lake Query
+This is a conceptual example of what a query might look like to satisfy AC-2. The exact field names and structure might vary based on the actual CloudTrail event schema.
+
+```sql
+SELECT
+    eventID,
+    eventName,
+    eventTime,
+    userIdentity.principalId,
+    requestParameters.tableName,
+    requestParameters.key
+FROM
+    <your_event_data_store_id>
+WHERE
+    eventSource = 'dynamodb.amazonaws.com'
+    AND eventName = 'GetItem'
+    AND requestParameters.tableName = 'TripTable' -- Or the actual name of the table
+    AND userIdentity.principalId = 'AROAXXXXXXXXXXXXXXXXXXXXX' -- Example Principal ID
+    AND eventTime > 'YYYY-MM-DDTHH:MM:SSZ' -- To scope the query if needed
+ORDER BY
+    eventTime DESC;
+```
+
+### Implementation Notes
+-   **CDK Configuration:** If possible, CloudTrail Lake and its event data store configurations (including data event selectors) will be defined using AWS CDK.
+-   **IAM Permissions:** Ensure that appropriate IAM permissions are in place for users or roles who need to query CloudTrail Lake.
+-   **Performance:** While AC-2 specifies < 30 seconds query time, actual performance can depend on the volume of data and query complexity. Efficient query design is important.
+-   **Cost:** Be mindful of CloudTrail Lake costs, which are based on ingestion and retention. Enabling data events can significantly increase the volume of logs.
+
+This setup will provide the necessary visibility for fleet managers to investigate incidents by reviewing who accessed specific trip data.

--- a/demo-scripts/README.md
+++ b/demo-scripts/README.md
@@ -1,0 +1,74 @@
+# Demonstration Scripts
+
+## Purpose
+This directory contains scripts and instructions for demonstrating specific capabilities of the EcoRoute Advisor system, particularly highlighting the latency advantages of AWS Wavelength Zones under constrained network conditions.
+
+## User Story
+As a judge (or evaluator), I want a demo script that throttles bandwidth to 1 Mbps and shows Wavelength still hitting < 1 s replans so that the telco value prop is obvious.
+
+## Acceptance Criteria
+-   **AC-1:** The script outputs side-by-side latency numbers (Wavelength vs. Region) in the terminal.
+-   **AC-2:** This README explains how to run the script on macOS and Windows.
+
+## Script Details (`latency_demo.sh` or similar)
+-   **Functionality:**
+    -   The script will likely make concurrent or sequential API calls to both the Wavelength-deployed `RoutePlanner` endpoint and the Region-deployed `RoutePlanner` endpoint.
+    -   It will measure and record the response time for each call.
+    -   It will output these latency figures clearly in the terminal, allowing for easy comparison.
+    -   The script itself might not perform bandwidth throttling but will rely on external tools. The instructions below will cover how to set up throttling.
+-   **Parameters:**
+    -   May accept API endpoint URLs as parameters or read them from a config file.
+    -   Could take a number of iterations to run the test multiple times.
+
+## Bandwidth Throttling Instructions
+
+### macOS
+macOS has built-in tools like `pf` (Packet Filter) or the Network Link Conditioner (part of Additional Tools for Xcode) that can be used to simulate various network conditions, including bandwidth throttling.
+
+**Using Network Link Conditioner (Recommended for ease of use):**
+1.  **Install Additional Tools for Xcode:**
+    -   Download from the Apple Developer website (search for "Additional Tools for Xcode").
+    -   Mount the DMG and find "Network Link Conditioner.prefPane" in the "Hardware" folder. Double-click to install it in System Preferences.
+2.  **Configure Throttling:**
+    -   Open System Preferences and go to "Network Link Conditioner".
+    -   Enable it.
+    -   Choose a profile that matches 1 Mbps or create a custom profile with:
+        -   Downlink Bandwidth: 1 Mbps
+        -   Uplink Bandwidth: (Adjust as needed, e.g., 1 Mbps or lower)
+        -   Packet Loss, Delay: (Keep at 0 or minimal for this specific test, unless testing other conditions)
+3.  **Run the Demo Script:** Execute the `latency_demo.sh` script in your terminal while the Network Link Conditioner is active.
+4.  **Disable Throttling:** Turn off the Network Link Conditioner in System Preferences after the demo.
+
+**Using `pf` (More advanced):**
+(Detailed instructions for `pf` can be complex and will be added if this method is preferred. It typically involves creating rules in `/etc/pf.conf` and using `dnctl` to create pipes for traffic shaping.)
+
+### Windows
+Windows can use tools like `Windows Sandbox` with network limitations, third-party software like `NetLimiter` or `TMeter`, or built-in `QoS Policies`.
+
+**Using Group Policy for QoS (Built-in, for outbound traffic):**
+1.  **Open Group Policy Editor:** Run `gpedit.msc`.
+2.  **Navigate to Policy-based QoS:**
+    -   Computer Configuration > Windows Settings > Policy-based QoS.
+3.  **Create a New Policy:**
+    -   Right-click and select "Create new policy...".
+    -   Policy Name: e.g., "Throttle to 1Mbps".
+    -   Specify Outbound Throttle Rate: Check this box and enter `1` MBps.
+    -   Click Next. Apply to "All applications" or specify the application/browser used for testing.
+    -   Click Next. Apply to "Any source IP address" and "Any destination IP address".
+    -   Click Next. Apply to "TCP and UDP" (or as needed).
+    -   Click Finish.
+4.  **Run the Demo Script:** Execute the demo script.
+5.  **Remove Policy:** Delete the QoS policy after the demo to restore normal bandwidth.
+
+**Using a Third-Party Tool (e.g., NetLimiter - may require a license):**
+1.  Install NetLimiter or a similar tool.
+2.  Configure a rule to limit the bandwidth for the specific application running the demo script (e.g., your terminal or browser) or globally to 1 Mbps.
+3.  Run the demo script.
+4.  Disable or remove the rule.
+
+## Running the Script
+```bash
+# Example (actual command might vary)
+./latency_demo.sh --wavelength-url <URL1> --region-url <URL2>
+```
+The script will then output latency readings for each endpoint.

--- a/devops/README.md
+++ b/devops/README.md
@@ -1,0 +1,33 @@
+# DevOps & Infrastructure
+
+## Purpose
+This section outlines the infrastructure setup and deployment strategy, particularly focusing on the deployment of the RoutePlanner Lambda function to both AWS Wavelength Zones and standard AWS Regions for A/B testing latency and performance.
+
+## User Story
+As a DevOps engineer, I want to deploy the optimisation Lambda (RoutePlanner) in both a Wavelength Zone (e.g., `us-wavelength-1`) and a standard region (e.g., `us-east-1`) so that we can A/B test latency.
+
+## Acceptance Criteria
+-   **AC-1:** `cdk deploy --context env=wavelength` provisions the edge stack successfully. (This implies the use of AWS CDK for infrastructure as code).
+-   **AC-2:** The RoutePlanner API (when invoked, regardless of where it's deployed) returns a header `X-Region-Id` (or a similar custom header) to indicate which path (Wavelength or standard Region) served the request.
+
+## Key Components & Strategy
+-   **Infrastructure as Code (IaC):**
+    -   AWS Cloud Development Kit (CDK) will be used to define and provision cloud resources.
+    -   Separate CDK stacks (or configurations within a stack) will be defined for:
+        -   The standard regional deployment (e.g., `us-east-1`).
+        -   The Wavelength Zone deployment (e.g., `us-wavelength-1-wl1-bos-wlz-1`).
+-   **RoutePlanner Lambda Deployment:**
+    -   The same Lambda function code for `RoutePlanner` will be deployed to both environments.
+    -   The Lambda will be configured to identify its execution environment (Region vs. Wavelength Zone) and include this information in its response (e.g., via the `X-Region-Id` header).
+-   **Deployment Process:**
+    -   The `cdk deploy` command with appropriate context parameters (like `--context env=wavelength` or `--context env=region`) will be used to target specific environments.
+-   **API Gateway:**
+    -   Each RoutePlanner Lambda (one in the Region, one in Wavelength) will likely be fronted by its own API Gateway endpoint.
+    -   The application logic (perhaps in the Fleet Manager Dashboard or a dedicated testing tool) will be responsible for calling both endpoints to compare latencies.
+-   **Configuration:**
+    -   Environment-specific configurations (e.g., SageMaker Geospatial endpoint configurations if they differ, though ideally they wouldn't for the same AWS region) will be managed through Lambda environment variables or CDK parameters.
+
+## Considerations for Wavelength Zones
+-   Wavelength Zones are extensions of an AWS Region into telecommunication providers' 5G networks.
+-   Not all AWS services are available in Wavelength Zones. The `RoutePlanner` Lambda's dependencies (e.g., SageMaker Geospatial SDK access) need to be compatible.
+-   Network paths and latency are key considerations. The goal is to demonstrate lower latency for requests originating from 5G devices when served by the Wavelength Zone.

--- a/driver-mobile-app/README.md
+++ b/driver-mobile-app/README.md
@@ -1,0 +1,33 @@
+# Driver Mobile App
+
+## Purpose
+This component provides a mobile-friendly web interface for drivers. It displays their current route, highlights updates in real-time, and shows recent eco-driving tips. The focus is on a distraction-free UI.
+
+## User Stories
+1.  **Route Updates**: As a driver, I want my mobile view to highlight the updated route in ≤ 5 s after optimisation so that I can adjust without confusion.
+2.  **Responsive UI & Eco-Tips**: As a driver, I want a responsive mobile page with only my vehicle’s route and last three eco-tips so that the UI is distraction-free.
+
+## Acceptance Criteria
+-   **AC-1 (Route Updates):** Given a route change, when the driver’s device receives a push event (or polls for an update), the new polyline is rendered in MapLibre within 5 seconds, and the old path is greyed out.
+-   **AC-2 (Responsive UI & Eco-Tips):**
+    -   Route polyline, next waypoint, and the last three eco-tips fit on a 390 × 844 screen (common mobile viewport).
+    -   Lighthouse mobile score ≥ 85.
+
+## Key Features
+-   **Map Display:** Uses MapLibre (or a similar mapping library) to render vehicle routes.
+-   **Real-time Updates:**
+    -   Listens for push events (e.g., via WebSockets or an equivalent AWS service like IoT Core or AppSync) or periodically polls for route changes.
+    -   Updates the map display promptly when a new route is received.
+    -   Visually differentiates new routes from old ones (e.g., new route in a prominent color, old route greyed out).
+-   **Eco-Tips Display:** Shows the last three eco-driving tips relevant to the driver/trip.
+-   **Responsive Design:** Ensures the UI is optimized for mobile devices, specifically targeting a 390x844 viewport.
+-   **Performance:** Aims for a high Lighthouse score for mobile performance, accessibility, and best practices.
+
+## Technology Stack (Proposed)
+-   **Frontend Framework:** (e.g., React, Vue, Angular, or plain HTML/CSS/JS)
+-   **Mapping Library:** MapLibre GL JS
+-   **Real-time Communication:** (e.g., AWS AppSync Subscriptions, AWS IoT Core for MQTT, or traditional WebSockets)
+
+## UI/UX Notes
+-   Minimalist design to reduce driver distraction.
+-   Clear visual hierarchy for route information and tips.

--- a/fleet-manager-dashboard/README.md
+++ b/fleet-manager-dashboard/README.md
@@ -1,0 +1,45 @@
+# Fleet Manager Dashboard
+
+## Purpose
+This component provides a web-based dashboard for dispatchers and fleet managers. It displays real-time vehicle positions, planned routes (original vs. eco-friendly), eco-tips, and key performance indicators like fuel and CO₂ savings. It's also intended to show a comparison of Edge vs. Region replan times.
+
+## User Stories
+1.  **Tip Logging Review**: As a fleet manager, I want the tips logged against each trip so that I can review driver coaching history. (This is primarily handled by `sustainability-analytics` for storage and API, but the dashboard will consume and display this data).
+2.  **Real-time ROI Dashboard**: As a dispatcher, I want a web dashboard that shows current vehicle positions, planned routes and litres saved so that I see ROI in real time.
+
+## Acceptance Criteria
+-   **AC-1 (Dashboard Updates):** Dashboard updates vehicle positions, routes, and metrics without requiring a manual refresh (leveraging AWS AppSync GraphQL subscriptions).
+-   **AC-2 (Metrics):** Metric card shows “Total CO₂ avoided (kg)” and matches the sum emitted to CloudWatch.
+-   **(Implied from Project Overview)** Displays:
+    -   Coloured truck icons moving on a map.
+    -   Green "eco" route vs. purple "original" route.
+    -   Running counters for litres & kg CO₂ saved.
+    -   A small chart comparing Edge vs. Region replan times.
+    -   List of vehicles.
+    -   Eco-tip pop-ups (potentially near vehicles or in a dedicated section).
+
+## Key Features
+-   **Map Display:**
+    -   Uses MapLibre GL JS to render vehicle positions and routes.
+    -   Shows distinct visual representations for the original route and the optimized "eco" route.
+    -   Displays animated truck icons at their current GPS locations.
+-   **Real-time Data:**
+    -   Subscribes to AWS AppSync (GraphQL) for real-time updates on vehicle positions, new routes, eco-tips, and calculated savings.
+    -   Ensures the dashboard reflects the latest information automatically.
+-   **Metrics Display:**
+    -   Clearly presents "Litres Saved" and "Total CO₂ avoided (kg)".
+    -   Includes a comparison chart for "Edge vs. Region" route replan latency.
+-   **Vehicle Information:** Lists vehicles in the fleet.
+-   **Eco-Tips Visualization:** Displays eco-tips, possibly as pop-up notifications or in a dedicated panel.
+-   **Driver Coaching History:** Allows fleet managers to review logged eco-tips for specific trips.
+
+## Technology Stack
+-   **Frontend Framework:** Next.js
+-   **Mapping Library:** MapLibre GL JS
+-   **Real-time API:** AWS AppSync (GraphQL Subscriptions)
+-   **Data Source:** DynamoDB (via AppSync)
+
+## UI/UX Notes
+-   The dashboard should provide a clear, at-a-glance overview of fleet status and performance.
+-   Designed for desktop use by dispatchers and fleet managers.
+-   Will serve as a central point for judges to see the sustainability payoff and the telco edge advantage.

--- a/ingestion/README.md
+++ b/ingestion/README.md
@@ -1,0 +1,21 @@
+# Ingestion Component
+
+## Purpose
+This component is responsible for handling the initial intake of GPS data into the system. It simulates a fleet without requiring hardware by allowing the upload of CSV files containing pre-recorded GPS pings.
+
+## User Story
+As a DevOps engineer, I want to upload a CSV file containing pre-recorded GPS pings so that we can simulate a fleet without hardware.
+
+## Acceptance Criteria
+- Given a CSV that matches the documented schema,
+- When I upload it to the S3 “ingest” bucket,
+- Then the file is versioned and a “file-received” EventBridge event is emitted.
+
+## Key Functionality
+-   **CSV Upload:** Allows users (specifically DevOps engineers or automated processes) to upload CSV files.
+-   **S3 Integration:** Uploaded files are stored in an S3 bucket designated for ingestion.
+-   **File Versioning:** S3 bucket will be configured to keep versions of uploaded files.
+-   **Event Emission:** Upon successful file upload and versioning, an event is published to AWS EventBridge, specifically a "file-received" event. This event will likely trigger downstream processes.
+
+## Schema
+(Details of the CSV schema will be documented here once finalized.)

--- a/optimisation-engine/README.md
+++ b/optimisation-engine/README.md
@@ -1,0 +1,23 @@
+# Optimisation Engine
+
+## Purpose
+This component is responsible for recomputing optimal vehicle routes to minimize fuel burn by avoiding congestion. It leverages SageMaker Geospatial for these calculations.
+
+## User Story
+As the optimisation engine, I want to call SageMaker Geospatial every 60 s to recompute shortest paths that avoid congestion so that fuel burn is minimised.
+
+## Acceptance Criteria
+-   **AC-1:** Replan requests sent to SageMaker Geospatial include the current coordinates of the vehicle and its destination.
+-   **AC-2:** The response received from SageMaker Geospatial returns a polyline representing the new path and an `estimatedLitresSaved` field.
+
+## Key Functionality
+-   **Scheduled Operations:** The engine is triggered every 60 seconds to perform route optimisation. This could be managed by a service like AWS Lambda with a CloudWatch Events trigger.
+-   **SageMaker Geospatial Integration:**
+    -   Constructs requests to SageMaker Geospatial, providing necessary inputs like current vehicle location (latitude, longitude) and destination.
+    -   Processes responses from SageMaker Geospatial to extract the new route (polyline) and estimated fuel savings.
+-   **Data Handling:**
+    -   Retrieves current vehicle locations and destinations (likely from a database or state store).
+    -   Stores or communicates the updated route information and savings, possibly by updating a database and/or emitting an event for other services (e.g., the Driver Mobile App).
+
+## Architecture Notes
+(Details about the specific SageMaker Geospatial APIs used, data flow, and how this engine interacts with other components will be added here.)

--- a/qa-tools/README.md
+++ b/qa-tools/README.md
@@ -1,0 +1,20 @@
+# QA Tools
+
+## Purpose
+This directory contains tools and resources for Quality Assurance (QA) testing and for setting up demonstration environments quickly.
+
+## User Story
+As a QA tester, I want a Postman collection that seeds sample files so that any team-mate can spin up a demo in < 5 min.
+
+## Acceptance Criteria
+-   **AC-1:** The Postman collection is checked into GitHub with this README.
+-   **AC-2:** Running “Seed Demo Fleet” (a request or set of requests within the Postman collection) results in at least 10 vehicles appearing on the dashboard within 30 seconds.
+
+## Components
+-   **Postman Collection:** A Postman collection will be provided here (`<collection_name>.postman_collection.json`). This collection will include requests to:
+    -   Seed the system with sample data (e.g., uploading sample CSV files via the ingestion component).
+    -   Potentially, verify endpoints or trigger specific workflows for testing purposes.
+-   **Sample Data:** Any necessary sample data files (e.g., sample CSVs for fleet simulation) used by the Postman collection might also be stored here or in a dedicated `sample-data` subdirectory.
+
+## Setup and Usage
+(Instructions on how to import the Postman collection and run the "Seed Demo Fleet" requests will be added here.)

--- a/reporting/README.md
+++ b/reporting/README.md
@@ -1,0 +1,32 @@
+# Reporting & Monitoring
+
+## Purpose
+This component is dedicated to monitoring and reporting on system performance, with a specific focus on comparing the latency of route replanning requests processed by the AWS Wavelength Zone versus the standard AWS Region.
+
+## User Story
+As a product owner, I want a Grafana panel that graphs median route-replan latency for both regions so that I can quantify the 20–30 % speedup target.
+
+## Acceptance Criteria
+-   **AC-1:** A Grafana dashboard (or panel within a dashboard) shows p50 (median) and p95 latency for route replanning requests for the last 24 hours, comparing Wavelength Zone vs. standard Region.
+-   **AC-2:** If Wavelength latency exceeds standard region latency for 3 consecutive minutes, an SNS alert fires.
+
+## Key Components
+-   **Metrics Collection:**
+    -   The `RoutePlanner` Lambda (in both Wavelength and Region deployments) will need to emit custom metrics, likely to Amazon CloudWatch. These metrics should include:
+        -   Request processing time (latency).
+        -   An identifier for the processing region (e.g., "wavelength_us-wl1-bos-1", "region_us-east-1").
+-   **Grafana Dashboard:**
+    -   A Grafana instance (either self-managed or using Amazon Managed Grafana) will be configured.
+    -   A data source connection to Amazon CloudWatch will be established.
+    -   Panels will be created to:
+        -   Graph p50 and p95 latencies over time (last 24 hours) for both Wavelength and Regional deployments side-by-side or overlaid.
+        -   Potentially display other relevant metrics.
+-   **Alerting:**
+    -   CloudWatch Alarms will be configured based on the latency metrics.
+    -   An alarm will be set to trigger if the Wavelength zone's p50 latency is greater than the standard region's p50 latency for a period of 3 consecutive minutes (e.g., 3 data points if metrics are emitted every minute).
+    -   This CloudWatch Alarm will be configured to publish a notification to an Amazon SNS topic when it enters the ALARM state.
+    -   Subscribers (e.g., email, SMS, or a Chime/Slack webhook via another Lambda) can be added to the SNS topic to receive these alerts.
+
+## Implementation Notes
+-   Ensure consistent tagging or dimensioning of CloudWatch metrics to easily distinguish between Wavelength and Regional data in Grafana and CloudWatch Alarms.
+-   The 20-30% speedup target should be visually verifiable from the Grafana dashboard.

--- a/security/README.md
+++ b/security/README.md
@@ -1,0 +1,77 @@
+# Security
+
+## Purpose
+This section details the security measures implemented within the EcoRoute Advisor project, with a primary focus on ensuring data is encrypted at rest using AWS Key Management Service (KMS).
+
+## User Story
+As a security officer, I want all location data encrypted at rest with AWS-managed KMS keys so that we meet basic compliance.
+
+## Acceptance Criteria
+-   **AC-1:** S3 buckets (e.g., the "ingest" bucket) and DynamoDB tables (e.g., tables storing trip data, eco-tips) have server-side encryption enabled, configured to use an AWS-managed KMS key (SSE-KMS with default `aws/s3` and `aws/dynamodb` keys, or a customer-managed key if specified). The example specifically mentions `AES-256` which is the algorithm used by SSE-S3 (AWS-managed keys for S3) and default for DynamoDB with AWS owned keys. If a specific KMS CMK is to be used, it should be specified. For now, we'll assume AWS-managed keys are sufficient.
+-   **AC-2:** The KMS key policy (if a customer-managed key is used) restricts cross-account access, allowing access only to necessary IAM roles and users within the same AWS account. (If using AWS-managed keys like `aws/s3` or `aws/dynamodb`, their policies are managed by AWS and generally don't allow cross-account access unless explicitly granted through bucket/table policies or IAM resource policies).
+
+## Encryption Strategy
+
+### Data at Rest
+-   **Amazon S3 Buckets:**
+    -   The S3 bucket used for CSV ingestion (`ingest` bucket) will have Server-Side Encryption (SSE) enabled.
+    -   By default, this can be SSE-S3 (using AES-256 encryption with keys managed by AWS S3) or SSE-KMS (using AWS KMS to manage encryption keys).
+    -   The user story mentions "AWS-managed KMS keys." This typically refers to AWS managed Customer Master Keys (CMKs) or the AWS owned keys for services. For S3, `aws/s3` is the AWS managed key. For DynamoDB, it's `aws/dynamodb`.
+    -   We will ensure that the `ingest` bucket is configured for server-side encryption using `AES-256` (which is what SSE-S3 provides, or SSE-KMS with an AWS-managed key).
+-   **Amazon DynamoDB Tables:**
+    -   All DynamoDB tables storing sensitive information (e.g., trip data, vehicle locations, eco-tips) will have server-side encryption enabled.
+    -   DynamoDB offers default encryption at rest using AWS owned keys at no additional charge.
+    -   Alternatively, an AWS managed KMS key (`aws/dynamodb`) or a customer-managed KMS key can be specified for encryption.
+    -   We will ensure encryption is active, defaulting to AWS owned keys or specifying `aws/dynamodb` if explicit KMS key selection is shown.
+-   **Amazon Location Service Trackers:**
+    -   Data stored in Amazon Location Service Trackers is encrypted at rest using AWS owned encryption keys.
+
+### Key Management
+-   **AWS Key Management Service (KMS):**
+    -   For services where we explicitly choose SSE-KMS, we will use AWS-managed keys (e.g., `alias/aws/s3`, `alias/aws/dynamodb`) unless a specific Customer Managed Key (CMK) is required.
+    -   If a CMK is created and used:
+        -   The key policy will be configured to follow the principle of least privilege.
+        -   It will restrict access to IAM roles and services within the AWS account that require encryption/decryption permissions.
+        -   Cross-account access will be explicitly denied unless there's a justified requirement (which is not indicated in the current user stories).
+
+## Implementation via AWS CDK (Example)
+When defining resources like S3 buckets or DynamoDB tables in AWS CDK, encryption properties will be explicitly set.
+
+**S3 Bucket Example (using SSE-S3 - AWS-managed key):**
+```typescript
+// Example in AWS CDK (TypeScript)
+new s3.Bucket(this, 'IngestBucket', {
+  encryption: s3.BucketEncryption.S3_MANAGED, // SSE-S3 (AES-256)
+  versioned: true, // As per ingestion user story
+});
+```
+
+**S3 Bucket Example (using SSE-KMS with AWS-managed s3 key):**
+```typescript
+// Example in AWS CDK (TypeScript)
+new s3.Bucket(this, 'IngestBucket', {
+  encryption: s3.BucketEncryption.KMS_MANAGED, // SSE-KMS using aws/s3 key by default
+  versioned: true,
+});
+```
+
+**DynamoDB Table Example (default AWS owned key):**
+```typescript
+// Example in AWS CDK (TypeScript)
+new dynamodb.Table(this, 'TripTable', {
+  partitionKey: { name: 'tripId', type: dynamodb.AttributeType.STRING },
+  // encryption: dynamodb.TableEncryption.AWS_MANAGED (this is default)
+});
+```
+
+**DynamoDB Table Example (AWS managed KMS key `aws/dynamodb`):**
+```typescript
+// Example in AWS CDK (TypeScript)
+new dynamodb.Table(this, 'TipTable', {
+  partitionKey: { name: 'tripId', type: dynamodb.AttributeType.STRING },
+  sortKey: { name: 'timestamp', type: dynamodb.AttributeType.STRING },
+  encryption: dynamodb.TableEncryption.AWS_MANAGED, // Corresponds to aws/dynamodb KMS key
+});
+```
+
+Further details on specific KMS key IDs and policies will be documented if Customer Managed Keys (CMKs) are implemented.

--- a/sustainability-analytics/README.md
+++ b/sustainability-analytics/README.md
@@ -1,0 +1,42 @@
+# Sustainability Analytics & Eco-Tips
+
+## Purpose
+This component focuses on promoting sustainable driving habits. It uses AWS Bedrock to generate personalized, bite-sized eco-tips for drivers based on their driving behavior. These tips are then logged for review.
+
+## User Stories
+1.  **Eco-Tip Generation**: As a sustainability analyst, I want Bedrock to generate bite-sized eco-tips based on driving behaviour so that drivers learn how to save fuel.
+2.  **Tip Logging**: As a fleet manager, I want the tips logged against each trip so that I can review driver coaching history.
+
+## Acceptance Criteria
+-   **AC-1 (Eco-Tip Generation):**
+    -   Agent prompt template for Bedrock is stored in AWS Parameter Store.
+    -   Given `speedVariance > 15 kph` (as an example input metric), when the tip is generated, then 80% of tips mention “steady acceleration”.
+-   **AC-2 (Tip Logging):**
+    -   Tips are written to DynamoDB with `tripId` as the partition key.
+    -   An API endpoint `/trips/{id}/tips` returns an array of tips for a given trip, ordered by timestamp.
+
+## Key Functionality
+-   **Behavior Analysis:** (Details to be defined) Consumes driving behavior data (e.g., speed variance, harsh braking/acceleration events).
+-   **Bedrock Integration:**
+    -   Retrieves a prompt template from AWS Parameter Store.
+    -   Formats the prompt with specific driving behavior data.
+    -   Invokes a Bedrock model to generate an eco-tip.
+-   **Tip Storage:**
+    -   Persists generated tips in a DynamoDB table.
+    -   Uses `tripId` as the partition key for efficient querying of tips per trip.
+    -   Includes a timestamp for ordering.
+-   **API for Tip Retrieval:**
+    -   Provides an API endpoint (e.g., via API Gateway and Lambda) to fetch tips for a specific trip.
+    -   Ensures tips are returned in chronological order.
+
+## Prompt Engineering Notes
+-   The prompt template in Parameter Store will be crucial for generating relevant and effective tips.
+-   It will need to be designed to guide the Bedrock model to focus on actionable advice related to the input driving behavior metrics.
+-   The example (`speedVariance > 15 kph` leading to "steady acceleration" tips) illustrates the desired specificity.
+
+## Data Models
+-   **DynamoDB Tip Record:**
+    -   `tripId` (String, Partition Key)
+    -   `timestamp` (Number or String ISO8601, Sort Key if needed for complex queries, or just an attribute for ordering)
+    -   `tipText` (String)
+    -   `triggeringBehavior` (Map, optional, e.g., `{ "metric": "speedVariance", "value": 18 }`)


### PR DESCRIPTION
I've set up the basic directory structure for your EcoRoute Advisor project. Each epic defined in the project overview now has its own folder. Each folder contains a README.md file that outlines:
- The purpose of the component/epic.
- Relevant user stories.
- Acceptance criteria.
- Key functionalities and technical considerations.

This initial structure provides a foundation for developing each component and aligns with your project's goals of simulating fleet operations, optimizing routes, providing real-time data, generating eco-tips, and ensuring security and auditability.

The created folders are:
- ingestion
- qa-tools
- optimisation-engine
- driver-mobile-app
- sustainability-analytics
- fleet-manager-dashboard
- devops
- reporting
- demo-scripts
- security
- audit

I've also updated the root README.md to provide an overview of the project and a list of these epics.